### PR TITLE
Add TDCC stock crawler skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/program1_crawler/__main__.py
+++ b/program1_crawler/__main__.py
@@ -1,0 +1,5 @@
+"""Module executed when running ``python -m program1_crawler``."""
+from .tdcc_crawler import run
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    run()

--- a/program1_crawler/fetch_stock_list.py
+++ b/program1_crawler/fetch_stock_list.py
@@ -1,0 +1,73 @@
+"""Utilities to fetch and filter Taiwanese stock codes from MoneyDJ."""
+from __future__ import annotations
+
+import logging
+import re
+from typing import Iterable, List, Tuple
+
+import requests
+from bs4 import BeautifulSoup
+
+# URL hosting the table with all Taiwanese stock codes
+MONEYDJ_STOCK_TABLE = "https://moneydj.emega.com.tw/js/StockTable.htm"
+
+# Patterns that indicate an entry should be excluded. These cover ETFs, bonds, warrants
+# and other non-equity instruments. The list can be extended over time.
+EXCLUDE_KEYWORDS = ["ETF", "債", "受益", "購", "權證"]
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_stock_table(url: str = MONEYDJ_STOCK_TABLE) -> str:
+    """Return the raw HTML/JS content hosting the stock table.
+
+    A small wrapper is used so that request related issues can be logged and
+    retried by callers if desired.
+    """
+    logger.debug("Fetching stock table from %s", url)
+    resp = requests.get(url, timeout=30)
+    resp.raise_for_status()
+    return resp.text
+
+
+def parse_stock_codes(html: str) -> List[Tuple[str, str]]:
+    """Parse the MoneyDJ table and return a list of (code, name) tuples.
+
+    The file mixes HTML and JavaScript; the approach here is to let BeautifulSoup
+    extract table rows and then use regular expressions for additional safety.
+    """
+    soup = BeautifulSoup(html, "lxml")
+    codes: List[Tuple[str, str]] = []
+    for row in soup.find_all("tr"):
+        cols = [c.get_text(strip=True) for c in row.find_all("td")]
+        if len(cols) >= 2 and re.fullmatch(r"\d{4}", cols[0]):
+            codes.append((cols[0], cols[1]))
+    return codes
+
+
+def filter_stock_codes(codes: Iterable[Tuple[str, str]]) -> List[str]:
+    """Filter out ETFs, bonds and other non-stock entries.
+
+    The filter is keyword based and keeps only the numeric stock codes.
+    """
+    filtered: List[str] = []
+    for code, name in codes:
+        if any(kw in name for kw in EXCLUDE_KEYWORDS):
+            logger.debug("Excluding %s %s", code, name)
+            continue
+        filtered.append(code)
+    return filtered
+
+
+def get_stock_codes() -> List[str]:
+    """Convenience function combining fetch, parse and filter steps."""
+    html = fetch_stock_table()
+    codes = parse_stock_codes(html)
+    return filter_stock_codes(codes)
+
+__all__ = [
+    "get_stock_codes",
+    "fetch_stock_table",
+    "parse_stock_codes",
+    "filter_stock_codes",
+]

--- a/program1_crawler/tdcc_crawler.py
+++ b/program1_crawler/tdcc_crawler.py
@@ -1,0 +1,80 @@
+"""Crawler for fetching stock holding distribution data from TDCC."""
+from __future__ import annotations
+
+import datetime as _dt
+import logging
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+from . import fetch_stock_list
+from .utils import request_with_retry, save_json
+
+TDCC_URL = "https://www.tdcc.com.tw/smWeb/QryStockAjax.do"
+logger = logging.getLogger(__name__)
+
+
+def generate_past_year_dates(today: _dt.date | None = None) -> List[str]:
+    """Return a list of date strings (YYYYMMDD) for the past 52 weeks."""
+    if today is None:
+        today = _dt.date.today()
+    start = today - _dt.timedelta(days=365)
+    dates = []
+    current = start
+    while current <= today:
+        dates.append(current.strftime("%Y%m%d"))
+        current += _dt.timedelta(days=7)
+    return dates
+
+
+def fetch_tdcc_data(stock_code: str, date: str) -> Dict:
+    """Fetch TDCC holding distribution for *stock_code* at *date*.
+
+    The returned JSON structure mirrors what the website provides. Actual keys may
+    vary and callers should be prepared to handle changes.
+    """
+    payload = {
+        "scaDates": date,
+        "scaDate": date,
+        "stkNo": stock_code,
+    }
+    logger.debug("Fetching TDCC data for %s at %s", stock_code, date)
+    resp = request_with_retry("post", TDCC_URL, data=payload)
+    return resp.json()
+
+
+def update_stock(stock_code: str, base_dir: Path = Path("data")) -> List[str]:
+    """Download new TDCC data for *stock_code*.
+
+    Returns a list of dates that were downloaded during this invocation.
+    """
+    stock_dir = base_dir / stock_code
+    existing = {p.stem for p in stock_dir.glob("*.json")}
+
+    target_dates = generate_past_year_dates()
+    new_dates = [d for d in target_dates if d not in existing]
+    downloaded: List[str] = []
+    for date in new_dates:
+        try:
+            data = fetch_tdcc_data(stock_code, date)
+        except Exception as exc:  # pragma: no cover - network dependent
+            logger.error("Failed to fetch %s %s: %s", stock_code, date, exc)
+            continue
+        save_json(stock_dir / f"{date}.json", data)
+        downloaded.append(date)
+    return downloaded
+
+
+def run() -> None:
+    """Entry point that fetches stock codes and updates them one by one."""
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    codes = fetch_stock_list.get_stock_codes()
+    for code in codes:
+        downloaded = update_stock(code)
+        if downloaded:
+            logger.info("%s: downloaded %s entries", code, len(downloaded))
+        else:
+            logger.info("%s: no new data", code)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    run()

--- a/program1_crawler/utils.py
+++ b/program1_crawler/utils.py
@@ -1,0 +1,45 @@
+"""Utility helpers for the crawler."""
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Callable, Dict
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def request_with_retry(
+    method: str,
+    url: str,
+    *,
+    max_retries: int = 3,
+    backoff: float = 1.0,
+    **kwargs: Any,
+) -> requests.Response:
+    """Perform an HTTP request with basic retry logic.
+
+    Parameters mirror :func:`requests.request`. Retries are attempted on any
+    :class:`requests.RequestException`.
+    """
+    for attempt in range(1, max_retries + 1):
+        try:
+            resp = requests.request(method, url, timeout=30, **kwargs)
+            resp.raise_for_status()
+            return resp
+        except requests.RequestException as exc:  # pragma: no cover - network dependent
+            logger.warning("Request failed (%s/%s): %s", attempt, max_retries, exc)
+            if attempt == max_retries:
+                raise
+            time.sleep(backoff * attempt)
+
+
+def save_json(path: str, data: Dict[str, Any]) -> None:
+    """Persist *data* to *path* in UTF-8 encoded JSON format."""
+    import json
+    from pathlib import Path
+
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, ensure_ascii=False, indent=2)


### PR DESCRIPTION
## Summary
- add MoneyDJ stock list fetcher with filtering of ETFs and other instruments
- implement TDCC crawler to download weekly holding distribution data with retry handling
- include helper utilities and entrypoint for running the crawler

## Testing
- `python -m py_compile program1_crawler/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68adbccf38fc8329970dec8ccd069969