### PR TITLE
Allow configurable TLS verification in TDCC crawler

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ python program1_tdcc_scraper.py
 # scraper.run(limit=5)
 ```
 
+#### SSL 驗證設定：
+
+爬蟲預設會驗證 HTTPS 憑證。可透過環境變數 `TDCC_SSL_VERIFY` 調整行為：
+
+- 未設定：使用系統預設 CA
+- 設為 CA 檔案路徑：使用指定憑證檔
+- 設為 `0` 或 `false`：停用驗證（僅限測試環境，正式執行請提供正確 CA 憑證）
+
 #### 輸出結果：
 - 建立 `stock_data/` 目錄
 - 每支股票一個子目錄（例如：`stock_data/2330/`）

--- a/program1_crawler/utils.py
+++ b/program1_crawler/utils.py
@@ -16,16 +16,21 @@ def request_with_retry(
     *,
     max_retries: int = 3,
     backoff: float = 1.0,
+    verify: bool | str = True,
     **kwargs: Any,
 ) -> requests.Response:
     """Perform an HTTP request with basic retry logic.
 
     Parameters mirror :func:`requests.request`. Retries are attempted on any
     :class:`requests.RequestException`.
+
+    The *verify* parameter matches the behaviour of the same argument in
+    :func:`requests.request`, allowing the caller to provide a custom CA bundle
+    path or disable verification.
     """
     for attempt in range(1, max_retries + 1):
         try:
-            resp = requests.request(method, url, timeout=30, **kwargs)
+            resp = requests.request(method, url, timeout=30, verify=verify, **kwargs)
             resp.raise_for_status()
             return resp
         except requests.RequestException as exc:  # pragma: no cover - network dependent


### PR DESCRIPTION
## Summary
- add `verify` option to `request_with_retry`
- allow TDCC crawler to configure SSL verification via `TDCC_SSL_VERIFY`
- document SSL verification options and caution against disabling in production

## Testing
- `python -m py_compile program1_crawler/utils.py program1_crawler/tdcc_crawler.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_68ade124bddc8329b5fb0c3268642b1b